### PR TITLE
Fix two multiply-defined bib references.

### DIFF
--- a/Projects/Madrzykowski_Thesis/References/Madrzykowski_Thesis.bib
+++ b/Projects/Madrzykowski_Thesis/References/Madrzykowski_Thesis.bib
@@ -193,7 +193,7 @@
    address = {Bethesda, MD},
 }
 
-@MISC{FDS-SMV_repository,
+@MISC{FDS-SMV_webpage,
   howpublished = {\url{https://github.com/firemodels/fds-smv}},
 }
 
@@ -646,7 +646,7 @@
    pages = {121-139},
 }
 
-@techreport{Bryant:2003,
+@techreport{Bryant:2003b,
    author = {Bryant, R.A. and Ohlemiller, T.J. and Johnsson, E.L. and Hamins, A.H. and Grove, B.S. and Guthrie, W.F. and Maranghides, A. and Mulholland, G.W.},
    title = {{The NIST 3~MW Quantitative Heat Release Rate Facility}},
    type = {NIST Special Publication},
@@ -1045,7 +1045,7 @@ Measurement in Liquid Pool Fires}},
 
 @misc{IAAI:2017,
   author = {International Association of Arson Investigators},
-  title = {Fire Dynamics Calculations - Version 2.0}, 
+  title = {Fire Dynamics Calculations - Version 2.0},
   howpublished = {www.cfitrainer.net},
   note = {Online; accessed February 20, 2017},
   }


### PR DESCRIPTION
When I ran bibtex, it complained that there were multiply-defined references. I "fixed" them by renaming the extra entries. You may want to go back and make sure that your cites of these documents are OK.